### PR TITLE
Set up RAM sections

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -1,9 +1,9 @@
 MEMORY {
     BOOT2(rx)   : ORIGIN = 0x10000000, LENGTH = 0x100
-    FLASH(rwx)  : ORIGIN = 0x10000100, LENGTH = 2048K - 0x100
+    FLASH(rx)  : ORIGIN = 0x10000100, LENGTH = 2048K - 0x100
     RAM(rwx)    : ORIGIN = 0x20000000, LENGTH = 256K
-    SMALL0(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
-    SMALL1(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
+    SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
+    SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
 }
 
 EXTERN(BOOT2_FIRMWARE)
@@ -13,21 +13,31 @@ SECTIONS {
     .boot2 ORIGIN(BOOT2) : {
         KEEP(*(.boot2));
     } > BOOT2
-
-    /* ### Main ram section */
-    /* .ram ORIGIN(RAM) : { TODO: FIXME: IDK HOW LINKERS WORK
-        *(.ram.*)
-        . = ALIGN(4);
-    } > RAM */
-
-    /* ### Small 4kb memory sections for high bandwidth code or data per core */
-    /* .small.0 ORIGIN(SMALL0) : { FIXME: THESE CAUSE EVERYTHING BUT PICO-DVI TO RUN
-        *(.small.0.*)
-        . = ALIGN(4);
-    } > SMALL0
-
-    .small.1 ORIGIN(SMALL1) : {
-        *(.small.1.*)
-        . = ALIGN(4);
-    } > SMALL1 */
 } INSERT BEFORE .text;
+
+SECTIONS {
+    /* ### Main ram section */
+    .ram : {
+        *(.ram .ram.*)
+        . = ALIGN(4);
+    } > RAM AT > FLASH
+} INSERT AFTER .data;
+
+SECTIONS {
+    /* ### Small 4kb memory sections for high bandwidth code or data per core */
+    .scratch_x : {
+        _scratch_x_start = .;
+        *(.scratch_x .scratch_x.*)
+        . = ALIGN(4);
+        _scratch_x_end = .;
+    } > SCRATCH_X AT > FLASH
+    _scratch_x_source = LOADADDR(.scratch_x);
+
+    .scratch_y : {
+        _scratch_y_start = .;
+        *(.scratch_y .scratch_y.*)
+        . = ALIGN(4);
+        _scratch_y_end = .;
+    } > SCRATCH_Y AT > FLASH
+    _scratch_y_source = LOADADDR(.scratch_y);
+} INSERT AFTER .rodata;

--- a/src/link.rs
+++ b/src/link.rs
@@ -3,9 +3,9 @@ macro_rules! link {
     (ram, $fn_name:ident) => {
         concat!(".ram.", file!(), ".", line!(), ".", stringify!($fn_name))
     };
-    (ram small 0, $fn_name:ident) => {
+    (scratch x, $fn_name:ident) => {
         concat!(
-            ".small.0.",
+            ".scratch_x.",
             file!(),
             ".",
             line!(),
@@ -13,9 +13,9 @@ macro_rules! link {
             stringify!($fn_name)
         )
     };
-    (ram small 1, $fn_name:ident) => {
+    (scratch y, $fn_name:ident) => {
         concat!(
-            ".small.1.",
+            ".scratch_y.",
             file!(),
             ".",
             line!(),


### PR DESCRIPTION
Set up linker sections for putting code (and statics) in RAM and also in scratch memories for faster bus access. A __pre_init function copies the initial contentents before starting main.

See https://github.com/rp-rs/rp-hal/issues/576 for more discusssion.