### PR TITLE
A number of fixes

### DIFF
--- a/src/dvi.rs
+++ b/src/dvi.rs
@@ -90,6 +90,7 @@ fn DMA_IRQ_0() {
     critical_section::with(|cs| {
         let mut guard = DVI_INST.borrow_ref_mut(cs);
         let inst = guard.as_mut().unwrap();
+        let _ = inst.channels.check_int();
         inst.timing_state.advance(&inst.timing);
         // wait for all three channels to load their last op
         inst.channels.wait_for_load(inst.timing.horiz_words());

--- a/src/dvi.rs
+++ b/src/dvi.rs
@@ -80,7 +80,6 @@ where
     pub fn start(&mut self) {
         self.channels.load_op(&self.dma_list_vblank_nosync);
         self.channels.start();
-        // TODO: wait for tx fifos full
     }
 }
 

--- a/src/dvi/dma.rs
+++ b/src/dvi/dma.rs
@@ -154,6 +154,10 @@ where
         self.lane1.wait_for_load(n_words);
         self.lane2.wait_for_load(n_words);
     }
+
+    pub fn check_int(&mut self) -> bool {
+        self.lane0.chan_data.check_irq0()
+    }
 }
 
 impl Default for DmaChannelConfig {

--- a/src/dvi/dma.rs
+++ b/src/dvi/dma.rs
@@ -3,10 +3,10 @@
 //! The PicoDVI source does not have a separate file for DMA; it's mostly
 //! split between dvi and dvi_timing.
 
-use rp_pico::hal::{
+use rp_pico::{hal::{
     dma::SingleChannel,
     pio::{Tx, ValidStateMachine},
-};
+}, pac::{Interrupt, NVIC}};
 
 use super::timing::DviScanlineDmaList;
 
@@ -134,6 +134,9 @@ where
     /// Enable interrupts and start the DMA transfers
     pub fn start(&mut self) {
         self.lane0.chan_data.listen_irq0();
+        unsafe {
+            NVIC::unmask(Interrupt::DMA_IRQ_0);
+        }
         let mut mask = 0;
         mask |= 1 << self.lane0.chan_ctrl.id();
         mask |= 1 << self.lane1.chan_ctrl.id();

--- a/src/dvi/dma.rs
+++ b/src/dvi/dma.rs
@@ -3,10 +3,13 @@
 //! The PicoDVI source does not have a separate file for DMA; it's mostly
 //! split between dvi and dvi_timing.
 
-use rp_pico::{hal::{
-    dma::SingleChannel,
-    pio::{Tx, ValidStateMachine},
-}, pac::{Interrupt, NVIC}};
+use rp_pico::{
+    hal::{
+        dma::SingleChannel,
+        pio::{Tx, ValidStateMachine},
+    },
+    pac::{Interrupt, NVIC},
+};
 
 use super::timing::DviScanlineDmaList;
 
@@ -144,7 +147,7 @@ where
         // TODO: bludgeon rp2040-hal, or whichever crate it is that's supposed to
         // be in charge of such things, into doing this the "right" way.
         unsafe {
-            let multi_chan_trigger: *mut u32 = 0x50000430 as *mut _;
+            let multi_chan_trigger: *mut u32 = 0x5000_0430 as *mut _;
             multi_chan_trigger.write_volatile(mask);
         }
     }

--- a/src/dvi/dma.rs
+++ b/src/dvi/dma.rs
@@ -86,6 +86,16 @@ where
             ch.ch_al1_ctrl.write(|w| w.bits(cfg.0));
         }
     }
+
+    fn wait_for_load(&self, n_words: u32) {
+        unsafe {
+            // CH{id}_DBG_TCR register, not exposed by HAL
+            let tcr = (0x5000_0804 + 0x40 * self.chan_data.id() as u32) as *mut u32;
+            while tcr.read_volatile() != n_words {
+                // tight_loop_contents()
+            }
+        }
+    }
 }
 
 impl<Ch0, Ch1, Ch2, Ch3, Ch4, Ch5> DmaChannels<Ch0, Ch1, Ch2, Ch3, Ch4, Ch5>
@@ -134,6 +144,12 @@ where
             let multi_chan_trigger: *mut u32 = 0x50000430 as *mut _;
             multi_chan_trigger.write_volatile(mask);
         }
+    }
+
+    pub fn wait_for_load(&self, n_words: u32) {
+        self.lane0.wait_for_load(n_words);
+        self.lane1.wait_for_load(n_words);
+        self.lane2.wait_for_load(n_words);
     }
 }
 

--- a/src/dvi/serializer.rs
+++ b/src/dvi/serializer.rs
@@ -7,7 +7,7 @@ use rp_pico::{
         },
         pio::{
             self, InstalledProgram, PIOBuilder, PinDir, Running, StateMachine, StateMachineGroup3,
-            StateMachineIndex, Stopped, Tx, UninitStateMachine,
+            StateMachineIndex, Stopped, Tx, UninitStateMachine, ValidStateMachine,
         },
         pwm::{self, FreeRunning, Slice, ValidPwmOutputPin},
     },
@@ -251,6 +251,12 @@ where
         &self.tx_fifo.2
     }
 
+    pub fn wait_fifos_full(&self) {
+        wait_fifo_full(self.tx0());
+        wait_fifo_full(self.tx1());
+        wait_fifo_full(self.tx2());
+    }
+
     pub fn enable(&mut self) {
         if let StateMachineState::Stopped(state_machines) =
             core::mem::replace(&mut self.state_machines, StateMachineState::Taken)
@@ -259,5 +265,11 @@ where
             self.state_machines = StateMachineState::Running(state_machines);
         }
         self.clock_pins.pwm_slice.enable();
+    }
+}
+
+fn wait_fifo_full<SM: ValidStateMachine>(fifo: &Tx<SM>) {
+    while !fifo.is_full() {
+        // tight_loop_contents()
     }
 }

--- a/src/dvi/timing.rs
+++ b/src/dvi/timing.rs
@@ -67,6 +67,10 @@ impl DviTiming {
             DviTimingLineState::Active => self.v_active_lines,
         }
     }
+
+    pub fn horiz_words(&self) -> u32 {
+        self.h_active_pixels / 2
+    }
 }
 
 impl DviTimingLineState {
@@ -185,7 +189,8 @@ impl DviScanlineDmaList {
     }
 }
 
-const DVI_CTRL_SYMS: [TmdsPair; 4] = [
+#[link_section = ".data"]
+static DVI_CTRL_SYMS: [TmdsPair; 4] = [
     TmdsPair::double(TmdsSym::C0),
     TmdsPair::double(TmdsSym::C1),
     TmdsPair::double(TmdsSym::C2),
@@ -196,7 +201,8 @@ fn get_ctrl_sym(vsync: bool, hsync: bool) -> &'static TmdsPair {
     &DVI_CTRL_SYMS[((vsync as usize) << 1) | (hsync as usize)]
 }
 
-const EMPTY_SCANLINE_TMDS: [TmdsPair; 3] = [
+#[link_section = ".data"]
+static EMPTY_SCANLINE_TMDS: [TmdsPair; 3] = [
     TmdsPair::encode_balanced_approx(0x00),
     TmdsPair::encode_balanced_approx(0x00),
     TmdsPair::encode_balanced_approx(0xfe),

--- a/src/dvi/tmds.rs
+++ b/src/dvi/tmds.rs
@@ -35,12 +35,12 @@ impl TmdsSym {
         let a = (byte << 1) ^ byte;
         let b = (a << 2) ^ a;
         let mut c = ((b << 4) ^ b) & 0xff;
-        let mut cnt_c = popcnt_byte(c);
         if cnt > 4 || (cnt == 4 && (c & 1) == 0) {
             c ^= 0xaa;
         } else {
             c ^= 0x100;
         }
+        let mut cnt_c = popcnt_byte(c & 0xff);
         let invert = if discrepancy == 0 || cnt_c == 4 {
             (c >> 8) == 0
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,12 +110,12 @@ fn entry() -> ! {
         peripherals.PIO0,
         &mut peripherals.RESETS,
         DviDataPins {
-            red_pos: pins.gpio10,
-            red_neg: pins.gpio11,
-            green_pos: pins.gpio12,
-            green_neg: pins.gpio13,
-            blue_pos: pins.gpio14,
-            blue_neg: pins.gpio15,
+            red_pos: pins.gpio10.into_mode(),
+            red_neg: pins.gpio11.into_mode(),
+            green_pos: pins.gpio12.into_mode(),
+            green_neg: pins.gpio13.into_mode(),
+            blue_pos: pins.gpio14.into_mode(),
+            blue_neg: pins.gpio15.into_mode(),
         },
         DviClockPins {
             clock_pos: pins.gpio8,

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,7 @@ fn entry() -> ! {
     critical_section::with(|cs| {
         inst.setup_dma();
         inst.start();
+        serializer.wait_fifos_full();
         serializer.enable();
         DVI_INST.borrow(cs).replace(Some(inst));
     });


### PR DESCRIPTION
Set GPIO pins to the appropriate mode rather than leaving it disabled.

Make PIO setup more correct, including 20 bits per FIFO pull, unity clock divisor, and setting FIFOs to Tx direction, shift direction right. Set pindir.

Wait for DMA config to load. Put symbols in RAM.

Fix bug in TMDS encoding.