### PR TITLE
Possibly fix the inverted colors

### DIFF
--- a/src/dvi/serializer.rs
+++ b/src/dvi/serializer.rs
@@ -133,9 +133,9 @@ where
 
         // Invert pin outputs if in other order
         let output_override = if positive_id < negative_id {
-            OutputOverride::Invert
-        } else {
             OutputOverride::DontInvert
+        } else {
+            OutputOverride::Invert
         };
 
         let (mut state_machine, _, tx) = PIOBuilder::from_program(unsafe { program.share() })

--- a/src/dvi/timing.rs
+++ b/src/dvi/timing.rs
@@ -210,7 +210,7 @@ fn get_ctrl_symbol(vsync: bool, hsync: bool) -> &'static TmdsPair {
 
 #[link_section = ".data"]
 static EMPTY_SCANLINE_TMDS: [TmdsPair; 3] = [
-    TmdsPair::encode_balanced_approx(0xff), // Blue
-    TmdsPair::encode_balanced_approx(0xff), // Green
-    TmdsPair::encode_balanced_approx(0x00), // Red
+    TmdsPair::encode_balanced_approx(0x00), // Blue
+    TmdsPair::encode_balanced_approx(0x00), // Green
+    TmdsPair::encode_balanced_approx(0xff), // Red
 ];


### PR DESCRIPTION
Looking over my wiring many times, I am certain that my wiring is correct, and the inverting of the positive and negative pins is happening in software.

The changes made in `src/dvi/serializer.rs` should fix the output being inverted, as the pio serializer by default uses the lower pin as the positive pin, and the higher pin as the inverted pin, so inversion of the output should happen when the negative pin is actually the lower pin.

Since the colors worked normally for you, applying directly to your code @raphlinus with your pinoutt would cause the colors to become inverted. My suspicion is that your pinout (`DviDataPins` struct) has the positive and negative pins accidentally flipped, causing the inversion to be unnoticed.

The reason I made this a PR vs just committing this change is that I wanted to check that my assumptions are true before committing it.