### PR TITLE
Use UnsafeCell for instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,6 @@ dependencies = [
  "bilge",
  "cortex-m",
  "cortex-m-rt",
- "critical-section",
  "defmt",
  "defmt-rtt",
  "defmt-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ repository = "https://github.com/DusterTheFirst/pico-dvi-rs"
 [dependencies]
 cortex-m         = "0.7.7"
 cortex-m-rt      = "0.7.3"
-critical-section = "1.1.1"
 embedded-alloc   = "0.5"
 embedded-hal     = "0.2.7"
 

--- a/src/dvi/dma.rs
+++ b/src/dvi/dma.rs
@@ -3,12 +3,9 @@
 //! The PicoDVI source does not have a separate file for DMA; it's mostly
 //! split between dvi and dvi_timing.
 
-use rp_pico::{
-    hal::{
-        dma::SingleChannel,
-        pio::{Tx, ValidStateMachine},
-    },
-    pac::{Interrupt, NVIC},
+use rp_pico::hal::{
+    dma::SingleChannel,
+    pio::{Tx, ValidStateMachine},
 };
 
 use super::timing::DviScanlineDmaList;
@@ -115,9 +112,6 @@ where
     /// Enable interrupts and start the DMA transfers
     pub fn start(&mut self) {
         self.lane0.data_channel.listen_irq0();
-        unsafe {
-            NVIC::unmask(Interrupt::DMA_IRQ_0);
-        }
         let mut mask = 0;
         mask |= 1 << self.lane0.control_channel.id();
         mask |= 1 << self.lane1.control_channel.id();


### PR DESCRIPTION
Reason about safety rather than using `critical_section` regarding exclusivity of access to the instance.

This shaves off a nontrivial amount of code from the interrupt handler, some of which was being called through thunks to XIP, rather than all being in RAM.