### PR TITLE
Introduce scanlist

### DIFF
--- a/src/dvi.rs
+++ b/src/dvi.rs
@@ -5,7 +5,7 @@ pub mod tmds;
 
 use alloc::boxed::Box;
 
-use crate::{pac::interrupt, DVI_INST};
+use crate::{pac::interrupt, render::ScanRender, DVI_INST};
 
 use self::{
     dma::{DmaChannelList, DmaChannels},
@@ -49,6 +49,7 @@ pub struct DviInst<Channels: DmaChannelList> {
     dma_list_error: DviScanlineDmaList,
 
     tmds_buf: Box<[TmdsPair]>,
+    scan_render: ScanRender,
 }
 
 impl<Channels: DmaChannelList> DviInst<Channels> {
@@ -64,6 +65,7 @@ impl<Channels: DmaChannelList> DviInst<Channels> {
             dma_list_active: Default::default(),
             dma_list_error: Default::default(),
             tmds_buf: buf.into(),
+            scan_render: ScanRender::new(),
         }
     }
 
@@ -127,7 +129,7 @@ impl<Channels: DmaChannelList> DviInst<Channels> {
                 let line_size = self.timing.horizontal_words() as usize * N_CHANNELS;
                 let line_start = line_size * buf_ix;
                 let tmds_slice = &mut self.tmds_buf[line_start..][..line_size];
-                crate::render::render_scanline(tmds_slice, y);
+                self.scan_render.render_scanline(tmds_slice, y);
             }
         }
     }

--- a/src/dvi/timing.rs
+++ b/src/dvi/timing.rs
@@ -5,7 +5,7 @@ use fugit::KilohertzU32;
 use rp_pico::hal::dma::SingleChannel;
 
 use super::{
-    dma::{DmaChannels, DmaControlBlock, DviLaneDmaCfg, DmaChannelList},
+    dma::{DmaChannelList, DmaChannels, DmaControlBlock, DviLaneDmaCfg},
     tmds::{TmdsPair, TmdsSymbol},
 };
 

--- a/src/dvi/tmds.rs
+++ b/src/dvi/tmds.rs
@@ -22,8 +22,8 @@ impl TmdsSymbol {
     pub const C2: Self = TmdsSymbol(0x154);
     pub const C3: Self = TmdsSymbol(0x2ab);
 
-    pub const fn encode(discrepancy: i32, byte: u32) -> (i32, Self) {
-        let byte_ones = u8::count_ones(byte as _);
+    pub const fn encode(discrepancy: i32, byte: u8) -> (i32, Self) {
+        let byte_ones = byte.count_ones();
 
         // The first step of encoding TMDS data is to XOR/XNOR each input bit with the previous output bit, one by one
         //
@@ -34,7 +34,7 @@ impl TmdsSymbol {
         // To reduce the amount of steps, the carry-less multiplication with 255
         // can be split up into a multiplication with 3 * 5 * 17. The following
         // 3 lines respectively can be seen as those smaller multiplications.
-        let byte_mul = (byte << 1) ^ byte;
+        let byte_mul = ((byte as u32) << 1) ^ byte as u32;
         let byte_mul = (byte_mul << 2) ^ byte_mul;
         let byte_mul = (byte_mul << 4) ^ byte_mul;
         // We only care about the bottom byte
@@ -88,10 +88,14 @@ impl TmdsPair {
     ///
     /// This method takes advantage of the fact that two values differing
     /// only in the least significant bit add are DC balanced.
-    pub const fn encode_balanced_approx(byte: u32) -> Self {
+    pub const fn encode_balanced_approx(byte: u8) -> Self {
         let (discrepancy, symbol_0) = TmdsSymbol::encode(0, byte);
         let (_, symbol_1) = TmdsSymbol::encode(discrepancy, byte ^ 1);
         Self::new(symbol_0, symbol_1)
+    }
+
+    pub const fn raw(self) -> u32 {
+        self.0
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ mod clock;
 mod dvi;
 mod link;
 mod render;
+mod scanlist;
 
 #[global_allocator]
 static HEAP: Heap = Heap::empty();

--- a/src/render.asm
+++ b/src/render.asm
@@ -1,0 +1,110 @@
+.section .data
+
+.global tmds_scan
+.type tmds_scan,%function
+.thumb_func
+// r0: scan list in direct threaded format
+// r1: input buffer
+// r2: output buffer
+// r3: stride (of output buffer)
+tmds_scan:
+    push {r4, r5, r6, r7}
+    mov r4, r8
+    mov r5, r9
+    mov r6, r10
+    push {r4, r5, r6}
+
+    // operation, 2x args
+    // should count be single pixels or double?
+    ldmia r0!, {r4, r5, r6}
+    bx r4
+
+.global tmds_scan_stop
+.type tmds_scan_stop,%function
+.thumb_func
+tmds_scan_stop:
+    subs r0, #8
+    pop {r4, r5, r6}
+    mov r8, r4
+    mov r9, r5
+    mov r10, r6
+    pop {r4, r5, r6, r7}
+    bx lr
+
+// args: count tmds_blue tmds_green tmds_red
+// Not sure we'll keep this.
+.global tmds_scan_solid_tmds
+.type tmds_scan_solid_tmds,%function
+.thumb_func
+tmds_scan_solid_tmds:
+    mov r8, r1
+    lsls r5, #2
+    adds r4, r2, r5
+    // ip is actual end of output
+    mov ip, r4
+    lsls r5, #28
+    lsrs r5, #28
+    adds r4, r2, r5
+    // r10 is end of fractional part (may be == r2)
+    mov r10, r4
+    adds r7, r2, r3 // beginning of green row
+    cmp r2, r10
+    beq 2f
+1:
+    stmia r2!, {r6}
+    cmp r2, r10
+    bne 1b
+    cmp r2, ip
+    beq 4f
+2:
+    mov r5, r6
+3:
+    stmia r2!, {r5, r6}
+    stmia r2!, {r5, r6}
+    cmp r2, ip
+    bne 3b
+4:
+
+    add ip, r3
+    add r10, r3
+    ldmia r0!, {r4, r6}
+    adds r1, r7, r3 // beginning of red row
+    cmp r7, r10
+    beq 2f
+1:
+    stmia r7!, {r4}
+    cmp r7, r10
+    bne 1b
+    cmp r7, ip
+    beq 4f
+2:
+    mov r5, r4
+3:
+    stmia r7!, {r4, r5}
+    stmia r7!, {r4, r5}
+    cmp r7, ip
+    bne 3b
+4:
+    // write red
+    add ip, r3
+    add r10, r3
+    cmp r1, r10
+    beq 2f
+1:
+    stmia r1!, {r6}
+    cmp r1, r10
+    bne 1b
+    cmp r1, ip
+    beq 4f
+2:
+    mov r7, r6
+3:
+    stmia r1!, {r6, r7}
+    stmia r1!, {r6, r7}
+    cmp r1, ip
+    bne 3b
+4:
+    mov r1, r8
+    ldmia r0!, {r4, r5, r6}
+    bx r4
+

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,67 +1,98 @@
-use crate::dvi::tmds::TmdsPair;
+use crate::{
+    dvi::{tmds::TmdsPair, VERTICAL_REPEAT},
+    scanlist::{Scanlist, ScanlistBuilder},
+};
 
-#[link_section = ".data"]
-static SMPTE_BARS: &[TmdsPair] = &[
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0x00),
-    // second row
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0x13),
-    TmdsPair::encode_balanced_approx(0x13),
-    TmdsPair::encode_balanced_approx(0x13),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x13),
-    TmdsPair::encode_balanced_approx(0x13),
-    TmdsPair::encode_balanced_approx(0x13),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0x00),
-    TmdsPair::encode_balanced_approx(0x13),
-    TmdsPair::encode_balanced_approx(0x13),
-    TmdsPair::encode_balanced_approx(0x13),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0xc0),
-    TmdsPair::encode_balanced_approx(0xc0),
-];
-
-#[link_section = ".data"]
-fn set_slice(slice: &mut [TmdsPair], val: TmdsPair) {
-    for x in slice {
-        *x = val;
-    }
+pub struct ScanRender {
+    scanlist: Scanlist,
+    stripe_remaining: u32,
+    scan_ptr: *const u32,
+    scan_next: *const u32,
 }
 
-#[link_section = ".data"]
-#[inline(never)]
-pub fn render_scanline(tmds_buf: &mut [TmdsPair], y: u32) {
-    let line = (y >= 160) as usize;
-    for chan in 0..3 {
-        for i in 0..7 {
-            let val = SMPTE_BARS[line * 21 + i * 3 + chan];
-            set_slice(&mut tmds_buf[(chan * 320 + i * 45)..][..45], val);
+core::arch::global_asm! {
+    include_str!("render.asm"),
+    options(raw)
+}
+
+extern "C" {
+    fn tmds_scan(
+        scan_list: *const u32,
+        input: *const u32,
+        output: *mut TmdsPair,
+        stride: u32,
+    ) -> *const u32;
+}
+
+fn rgb(r: u8, g: u8, b: u8) -> [TmdsPair; 3] {
+    [
+        TmdsPair::encode_balanced_approx(b),
+        TmdsPair::encode_balanced_approx(g),
+        TmdsPair::encode_balanced_approx(r),
+    ]
+}
+
+impl ScanRender {
+    pub fn new() -> Self {
+        let mut sb = ScanlistBuilder::new(640, 480 / VERTICAL_REPEAT as u32);
+        sb.begin_stripe(320 / VERTICAL_REPEAT as u32);
+        sb.solid(92, rgb(0xc0, 0xc0, 0xc0));
+        sb.solid(90, rgb(0xc0, 0xc0, 0));
+        sb.solid(92, rgb(0, 0xc0, 0xc0));
+        sb.solid(92, rgb(0, 0xc0, 0x0));
+        sb.solid(92, rgb(0xc0, 0, 0xc0));
+        sb.solid(90, rgb(0xc0, 0, 0));
+        sb.solid(92, rgb(0, 0, 0xc0));
+        sb.end_stripe();
+        sb.begin_stripe(40 / VERTICAL_REPEAT as u32);
+        sb.solid(92, rgb(0, 0, 0xc0));
+        sb.solid(90, rgb(0x13, 0x13, 0x13));
+        sb.solid(92, rgb(0xc0, 0, 0xc0));
+        sb.solid(92, rgb(0x13, 0x13, 0x13));
+        sb.solid(92, rgb(0, 0xc0, 0xc0));
+        sb.solid(90, rgb(0x13, 0x13, 0x13));
+        sb.solid(92, rgb(0xc0, 0xc0, 0xc0));
+        sb.end_stripe();
+        sb.begin_stripe(120 / VERTICAL_REPEAT as u32);
+        sb.solid(114, rgb(0, 0x21, 0x4c));
+        sb.solid(114, rgb(0xff, 0xff, 0xff));
+        sb.solid(114, rgb(0x32, 0, 0x6a));
+        sb.solid(116, rgb(0x13, 0x13, 0x13));
+        sb.solid(30, rgb(0x09, 0x09, 0x09));
+        sb.solid(30, rgb(0x13, 0x13, 0x13));
+        sb.solid(30, rgb(0x1d, 0x1d, 0x1d));
+        sb.solid(92, rgb(0x13, 0x13, 0x13));
+        sb.end_stripe();
+        let scanlist = sb.build();
+        let stripe_remaining = 0;
+        let scan_ptr = core::ptr::null();
+        let scan_next = core::ptr::null();
+        ScanRender {
+            scanlist,
+            stripe_remaining,
+            scan_ptr,
+            scan_next,
+        }
+    }
+
+    #[link_section = ".data"]
+    #[inline(never)]
+    pub fn render_scanline(&mut self, tmds_buf: &mut [TmdsPair], y: u32) {
+        unsafe {
+            if y == 0 {
+                self.scan_next = self.scanlist.get().as_ptr();
+            }
+            if self.stripe_remaining == 0 {
+                self.stripe_remaining = self.scan_next.read();
+                self.scan_ptr = self.scan_next.add(1);
+            }
+            self.scan_next = tmds_scan(
+                self.scan_ptr,
+                core::ptr::null(),
+                tmds_buf.as_mut_ptr(),
+                1280,
+            );
+            self.stripe_remaining -= 1;
         }
     }
 }

--- a/src/scanlist.rs
+++ b/src/scanlist.rs
@@ -1,0 +1,77 @@
+use alloc::vec::Vec;
+
+use crate::dvi::tmds::TmdsPair;
+
+extern "C" {
+    fn tmds_scan_stop();
+
+    fn tmds_scan_solid_tmds();
+}
+
+/// A display list for TMDS scanout.
+///
+/// A scanlist contains a description of how to render the scene into
+/// TMDS encoded scan lines. The input to this stage is intended to be
+/// line buffers, but at present only solid color blocks are implemented.
+///
+/// There are a number of safety requirements, as the scanlist is
+/// interpreted by an unsafe virtual machine. The width of each scanline
+/// must match the actual buffer provided, and the total height must
+/// also be the number of scanlines.
+///
+/// One potential direction is to make the scanlist builder enforce the
+/// safety requirements. This would have a modest runtime cost (none
+/// during scanout).
+pub struct Scanlist(Vec<u32>);
+
+/// A builder for scanlists.
+///
+/// The application builds a scanlist, then hands it to the display
+/// system for scanout. Currently it is static, but the intent is for
+/// scanlists to be double-buffered.
+pub struct ScanlistBuilder {
+    v: Vec<u32>,
+    x: u32,
+}
+
+impl ScanlistBuilder {
+    pub fn new(_width: u32, _height: u32) -> Self {
+        ScanlistBuilder {
+            v: alloc::vec![],
+            x: 0,
+        }
+    }
+
+    pub fn build(self) -> Scanlist {
+        // TODO: check width, do some kind of error?
+        Scanlist(self.v)
+    }
+
+    pub fn begin_stripe(&mut self, height: u32) {
+        self.v.push(height);
+    }
+
+    pub fn end_stripe(&mut self) {
+        self.v.push(tmds_scan_stop as u32);
+    }
+
+    /// Generate a run of solid color.
+    ///
+    /// This method only works when aligned to 2-pixel boundaries.
+    pub fn solid(&mut self, count: u32, color: [TmdsPair; 3]) {
+        self.v.extend([
+            tmds_scan_solid_tmds as u32,
+            count / 2,
+            color[0].raw(),
+            color[1].raw(),
+            color[2].raw(),
+        ]);
+        self.x += count;
+    }
+}
+
+impl Scanlist {
+    pub fn get(&self) -> &[u32] {
+        &self.0
+    }
+}


### PR DESCRIPTION
This patch creates a virtual machine for rendering TMDS-encoded scanlines from a display list. The display is an improved version of the SMPTE colorbars.

Only solid color blocks are currently implemented, but the virtual machine is extensible and the next step is to convert low bit depth line buffers into full TMDS scanlines.