### PR TITLE
Swappable BSP crates behind a feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "adafruit-feather-rp2040"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5dcc126017a99c6754575dd4c4bb47625e187179b5bea776c31bf4b9235240"
+dependencies = [
+ "cortex-m-rt",
+ "rp2040-boot2",
+ "rp2040-hal",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,7 +628,7 @@ dependencies = [
  "panic-probe",
  "pio",
  "pio-proc",
- "rp-pico",
+ "rp2040-bsp",
 ]
 
 [[package]]
@@ -798,6 +809,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c92f344f63f950ee36cf4080050e4dce850839b9175da38f9d2ffb69b4dbb21"
 dependencies = [
  "crc-any",
+]
+
+[[package]]
+name = "rp2040-bsp"
+version = "0.0.0"
+dependencies = [
+ "adafruit-feather-rp2040",
+ "rp-pico",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ resolver = "2"
 publish = false
 version = "0.0.0"
 
+[workspace]
+members = ["crates/*"]
+
 [dependencies]
 cortex-m       = "0.7.7"
 cortex-m-rt    = "0.7.3"
@@ -25,10 +28,15 @@ panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 fugit    = { version = "0.3.6", features = ["defmt"] }
 pio      = "0.2.1"
 pio-proc = "0.2.1"
-rp-pico  = { version = "0.8.0", features = ["rom-v2-intrinsics"] }
 
-# TODO: use for bitfield
+rp2040-bsp = { path = "./crates/rp2040-bsp" }
+
+# TODO: use for bitfields
 # bilge = "0.1.5"
+
+[features]
+adafruit-feather-rp2040 = ["rp2040-bsp/adafruit-feather-rp2040"]
+rp-pico                 = ["rp2040-bsp/rp-pico"]
 
 [dev-dependencies]
 defmt-test = "0.3.0"

--- a/crates/rp2040-bsp/Cargo.toml
+++ b/crates/rp2040-bsp/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rp2040-bsp"
+
+description = "Generic rp2040 board support package crate"
+version     = "0.0.0"
+
+edition = "2021"
+publish = false
+
+[dependencies]
+# Board Support Crates (choose one)
+adafruit-feather-rp2040 = { version = "0.7.0", features = ["rom-v2-intrinsics"], optional = true }
+rp-pico                 = { version = "0.8.0", features = ["rom-v2-intrinsics"], optional = true }
+
+[features]
+default           = ["rom-v2-intrinsics"]
+rom-v2-intrinsics = ["adafruit-feather-rp2040?/rom-v2-intrinsics", "rp-pico?/rom-v2-intrinsics"]
+
+# Board Support Crates (choose one)
+adafruit-feather-rp2040 = ["dep:adafruit-feather-rp2040"]
+rp-pico                 = ["dep:rp-pico"]

--- a/crates/rp2040-bsp/src/lib.rs
+++ b/crates/rp2040-bsp/src/lib.rs
@@ -1,0 +1,55 @@
+#![no_std]
+
+// https://github.com/rust-lang/rust/issues/115585 polyfill until stabilized
+// Implementation taken from stdlib (https://github.com/rust-lang/rust/pull/115416/files#diff-7fdf8ef3b0e02b28e3caa4cc144046f9510df7c8a1f524124f4921601a3d7456)
+macro_rules! cfg_match {
+    (
+        $(cfg($initial_meta:meta) => { $($initial_tokens:item)* })+
+        _ => { $($extra_tokens:item)* }
+    ) => {
+        cfg_match! {
+            @__items ();
+            $((($initial_meta) ($($initial_tokens)*)),)+
+            (() ($($extra_tokens)*)),
+        }
+    };
+    (
+        $(cfg($extra_meta:meta) => { $($extra_tokens:item)* })*
+    ) => {
+        cfg_match! {
+            @__items ();
+            $((($extra_meta) ($($extra_tokens)*)),)*
+        }
+    };
+    (@__items ($($_:meta,)*);) => {};
+    (
+        @__items ($($no:meta,)*);
+        (($($yes:meta)?) ($($tokens:item)*)),
+        $($rest:tt,)*
+    ) => {
+        #[cfg(all(
+            $($yes,)?
+            not(any($($no),*))
+        ))]
+        cfg_match! { @__identity $($tokens)* }
+        cfg_match! {
+            @__items ($($no,)* $($yes,)?);
+            $($rest,)*
+        }
+    };
+    (@__identity $($tokens:item)*) => {
+        $($tokens)*
+    };
+}
+
+cfg_match! {
+    cfg(feature = "rp-pico") => {
+        pub use rp_pico::*;
+    }
+    cfg(feature = "adafruit-feather-rp2040") => {
+        pub use adafruit_feather_rp2040::*;
+    }
+    _ => {
+        compile_error!("One of the board support crate features must be enabled (see rp2040-bsp's Cargo.toml)");
+    }
+}

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,5 +1,5 @@
 use fugit::{KilohertzU32, MegahertzU32, RateExtU32};
-use rp_pico::{
+use rp2040_bsp::{
     hal::{
         clocks::{ClockSource, ClocksManager},
         pll::{

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1,6 +1,6 @@
 use alloc::format;
 use embedded_hal::digital::v2::ToggleableOutputPin;
-use rp_pico::hal::gpio::{FunctionSioOutput, Pin, PinId, PullDown};
+use rp2040_bsp::hal::gpio::{FunctionSioOutput, Pin, PinId, PullDown};
 
 use crate::{
     dvi::VERTICAL_REPEAT,

--- a/src/dvi.rs
+++ b/src/dvi.rs
@@ -5,7 +5,7 @@ pub mod tmds;
 
 use alloc::boxed::Box;
 use cortex_m::peripheral::NVIC;
-use rp_pico::hal::{
+use rp2040_bsp::hal::{
     gpio::PinId,
     pac::Interrupt,
     pio,

--- a/src/dvi/dma.rs
+++ b/src/dvi/dma.rs
@@ -3,7 +3,7 @@
 //! The PicoDVI source does not have a separate file for DMA; it's mostly
 //! split between dvi and dvi_timing.
 
-use rp_pico::hal::{
+use rp2040_bsp::hal::{
     dma::SingleChannel,
     pio::{Tx, ValidStateMachine},
 };

--- a/src/dvi/serializer.rs
+++ b/src/dvi/serializer.rs
@@ -1,5 +1,5 @@
 use embedded_hal::PwmPin;
-use rp_pico::{
+use rp2040_bsp::{
     hal::{
         gpio::{
             FunctionPio0, FunctionPwm, OutputDriveStrength, OutputOverride, OutputSlewRate, Pin,

--- a/src/dvi/timing.rs
+++ b/src/dvi/timing.rs
@@ -2,7 +2,7 @@
 //! <https://github.com/Wren6991/PicoDVI/blob/51237271437e9d1eb62c97e40171fbf6ffe01ac6/software/libdvi/dvi_timing.c>
 
 use fugit::KilohertzU32;
-use rp_pico::hal::dma::SingleChannel;
+use rp2040_bsp::hal::dma::SingleChannel;
 
 use super::{
     dma::{DmaChannelList, DmaChannels, DmaControlBlock, DviLaneDmaCfg},

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use cortex_m::peripheral::NVIC;
 use defmt::{dbg, info};
 use dvi::dma::DmaChannelList;
 use embedded_alloc::Heap;
-use rp_pico::{
+use rp2040_bsp::{
     hal::{
         dma::{Channel, DMAExt, CH0, CH1, CH2, CH3, CH4, CH5},
         gpio::PinState,
@@ -82,7 +82,7 @@ static mut CORE1_STACK: Stack<256> = Stack::new();
 static mut FIFO: MaybeUninit<SioFifo> = MaybeUninit::uninit();
 
 // Separate macro annotated function to make rust-analyzer fixes apply better
-#[rp_pico::entry]
+#[rp2040_bsp::entry]
 fn macro_entry() -> ! {
     entry();
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -9,7 +9,7 @@ pub use palette::{init_4bpp_palette, PaletteEntry, BW_PALETTE, GLOBAL_PALETTE};
 
 use core::sync::atomic::{compiler_fence, AtomicBool, Ordering};
 
-use rp_pico::{
+use rp2040_bsp::{
     hal::{sio::SioFifo, Sio},
     pac,
 };


### PR DESCRIPTION
In order to help users who do not share the same pinout or board, it can be possible to swap out the board support package and pinout based on feature flags.

I was able to implement the ability to swap out the board support packages. I did this by having a separate crate that just re-exports each bsp based on the feature flags. This removes the need to cfg off each bsp in all of the files, and it works well with lsp tools like rust-analyzer as it will suggest imports from the re-exports which would not be suggested if the cfg-ing happened in the same crate.

This is not finished, as it does not switch the pinouts, just the board support crate. I am unsure how to switch the pinouts. We could:
1) Somehow export the pinout from the helper bsp crate based on the features selected
2) cfg off the pinout in the main crate

I do not like 2 as it adds 2 places where these cfg statements are placed, rather than consolidating them in one file/crate. 1 could be possible but I am not too sure how to go about implementing it. 

I do not think that even if 1 or 2 are implemented that this would be a good system. I think a better approach would be to move the main crate to a library, with 2 separate  bins that would consume it, passing their respective pinouts. (See #16 for an attempt at this)