### PR TITLE
Other idea for swappable BSPs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "adafruit-feather-rp2040"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5dcc126017a99c6754575dd4c4bb47625e187179b5bea776c31bf4b9235240"
+dependencies = [
+ "cortex-m-rt",
+ "rp2040-boot2",
+ "rp2040-hal",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +617,7 @@ dependencies = [
 name = "pico-dvi-rs"
 version = "0.0.0"
 dependencies = [
+ "adafruit-feather-rp2040",
  "cortex-m",
  "cortex-m-rt",
  "defmt",
@@ -618,6 +630,7 @@ dependencies = [
  "pio",
  "pio-proc",
  "rp-pico",
+ "rp2040-hal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,20 @@ defmt       = "0.3.2"
 defmt-rtt   = "0.4.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 
-fugit    = { version = "0.3.6", features = ["defmt"] }
-pio      = "0.2.1"
-pio-proc = "0.2.1"
-rp-pico  = { version = "0.8.0", features = ["rom-v2-intrinsics"] }
+fugit      = { version = "0.3.6", features = ["defmt"] }
+pio        = "0.2.1"
+pio-proc   = "0.2.1"
+rp2040-hal = { version = "0.9.0", features = ["rt"] }
 
 # TODO: use for bitfield
 # bilge = "0.1.5"
 
 [dev-dependencies]
 defmt-test = "0.3.0"
+
+# Board support packages
+adafruit-feather-rp2040 = { version = "0.7.0", features = ["rom-v2-intrinsics", "rp2040-e5"] }
+rp-pico                 = { version = "0.8.0", features = ["rom-v2-intrinsics", "rp2040-e5"] }
 
 # cargo build/run
 [profile.dev]

--- a/examples/adafruit-feather-rp2040.rs
+++ b/examples/adafruit-feather-rp2040.rs
@@ -1,0 +1,53 @@
+#![no_std]
+#![no_main]
+
+use adafruit_feather_rp2040::{
+    hal::{gpio::PinState, pwm, sio::Sio},
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+
+use pico_dvi_rs::{
+    core0_main,
+    dvi::serializer::{DviClockPins, DviDataPins},
+};
+
+// Separate macro annotated function to make rust-analyzer fixes apply better
+#[rp_pico::entry]
+fn macro_entry() -> ! {
+    entry();
+}
+
+fn entry() -> ! {
+    core0_main::<XOSC_CRYSTAL_FREQ, _, _, _, _, _, _, _, _, _, _, _>(
+        |sio, io_bank0, pads_bank0, pwm, resets| {
+            let single_cycle_io = Sio::new(sio);
+
+            let pins = Pins::new(io_bank0, pads_bank0, single_cycle_io.gpio_bank0, resets);
+
+            let led_pin = pins.FIXME.into_push_pull_output_in_state(PinState::Low);
+
+            let pwm_slices = pwm::Slices::new(pwm, resets);
+
+            (
+                led_pin,
+                DviDataPins {
+                    // 0
+                    blue_pos: pins.FIXME.into_function(),
+                    blue_neg: pins.FIXME.into_function(),
+                    // 1
+                    green_pos: pins.FIXME.into_function(),
+                    green_neg: pins.FIXME.into_function(),
+                    // 2
+                    red_pos: pins.FIXME.into_function(),
+                    red_neg: pins.FIXME.into_function(),
+                },
+                DviClockPins {
+                    clock_pos: pins.FIXME.into_function(),
+                    clock_neg: pins.FIXME.into_function(),
+                    pwm_slice: pwm_slices.pwm7,
+                },
+                single_cycle_io.fifo,
+            )
+        },
+    );
+}

--- a/examples/rp-pico.rs
+++ b/examples/rp-pico.rs
@@ -1,0 +1,53 @@
+#![no_std]
+#![no_main]
+
+use rp_pico::{
+    hal::{gpio::PinState, pwm, sio::Sio},
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+
+use pico_dvi_rs::{
+    core0_main,
+    dvi::serializer::{DviClockPins, DviDataPins},
+};
+
+// Separate macro annotated function to make rust-analyzer fixes apply better
+#[rp_pico::entry]
+fn macro_entry() -> ! {
+    entry();
+}
+
+fn entry() -> ! {
+    core0_main::<XOSC_CRYSTAL_FREQ, _, _, _, _, _, _, _, _, _, _, _>(
+        |sio, io_bank0, pads_bank0, pwm, resets| {
+            let single_cycle_io = Sio::new(sio);
+
+            let pins = Pins::new(io_bank0, pads_bank0, single_cycle_io.gpio_bank0, resets);
+
+            let led_pin = pins.led.into_push_pull_output_in_state(PinState::Low);
+
+            let pwm_slices = pwm::Slices::new(pwm, resets);
+
+            (
+                led_pin,
+                DviDataPins {
+                    // 0
+                    blue_pos: pins.gpio12.into_function(),
+                    blue_neg: pins.gpio13.into_function(),
+                    // 1
+                    green_pos: pins.gpio10.into_function(),
+                    green_neg: pins.gpio11.into_function(),
+                    // 2
+                    red_pos: pins.gpio16.into_function(),
+                    red_neg: pins.gpio17.into_function(),
+                },
+                DviClockPins {
+                    clock_pos: pins.gpio14.into_function(),
+                    clock_neg: pins.gpio15.into_function(),
+                    pwm_slice: pwm_slices.pwm7,
+                },
+                single_cycle_io.fifo,
+            )
+        },
+    );
+}

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1,6 +1,6 @@
 use alloc::format;
 use embedded_hal::digital::v2::ToggleableOutputPin;
-use rp_pico::hal::gpio::{FunctionSioOutput, Pin, PinId, PullDown};
+use rp2040_hal::gpio::{FunctionSioOutput, Pin, PinId, PullDown};
 
 use crate::{
     dvi::VERTICAL_REPEAT,

--- a/src/dvi.rs
+++ b/src/dvi.rs
@@ -5,15 +5,14 @@ pub mod tmds;
 
 use alloc::boxed::Box;
 use cortex_m::peripheral::NVIC;
-use rp_pico::hal::{
+use rp2040_hal::{
     gpio::PinId,
-    pac::Interrupt,
+    pac::{Interrupt, interrupt},
     pio,
     pwm::{self, ValidPwmOutputPin},
 };
 
 use crate::{
-    pac::interrupt,
     render::{render_line, ScanRender, CORE1_QUEUE, N_LINE_BUFS},
     DVI_INST,
 };

--- a/src/dvi/dma.rs
+++ b/src/dvi/dma.rs
@@ -3,7 +3,7 @@
 //! The PicoDVI source does not have a separate file for DMA; it's mostly
 //! split between dvi and dvi_timing.
 
-use rp_pico::hal::{
+use rp2040_hal::{
     dma::SingleChannel,
     pio::{Tx, ValidStateMachine},
 };

--- a/src/dvi/serializer.rs
+++ b/src/dvi/serializer.rs
@@ -1,17 +1,15 @@
 use embedded_hal::PwmPin;
-use rp_pico::{
-    hal::{
-        gpio::{
-            FunctionPio0, FunctionPwm, OutputDriveStrength, OutputOverride, OutputSlewRate, Pin,
-            PinId, PullDown,
-        },
-        pio::{
-            self, InstalledProgram, PIOBuilder, PinDir, Running, StateMachine, StateMachineGroup3,
-            StateMachineIndex, Stopped, Tx, UninitStateMachine, ValidStateMachine,
-        },
-        pwm::{self, FreeRunning, Slice, ValidPwmOutputPin},
+use rp2040_hal::{
+    gpio::{
+        FunctionPio0, FunctionPwm, OutputDriveStrength, OutputOverride, OutputSlewRate, Pin, PinId,
+        PullDown,
     },
     pac,
+    pio::{
+        self, InstalledProgram, PIOBuilder, PinDir, Running, StateMachine, StateMachineGroup3,
+        StateMachineIndex, Stopped, Tx, UninitStateMachine, ValidStateMachine,
+    },
+    pwm::{self, FreeRunning, Slice, ValidPwmOutputPin},
 };
 
 pub struct DviDataPins<RedPos, RedNeg, GreenPos, GreenNeg, BluePos, BlueNeg>

--- a/src/dvi/timing.rs
+++ b/src/dvi/timing.rs
@@ -2,7 +2,7 @@
 //! <https://github.com/Wren6991/PicoDVI/blob/51237271437e9d1eb62c97e40171fbf6ffe01ac6/software/libdvi/dvi_timing.c>
 
 use fugit::KilohertzU32;
-use rp_pico::hal::dma::SingleChannel;
+use rp2040_hal::dma::SingleChannel;
 
 use super::{
     dma::{DmaChannelList, DmaChannels, DmaControlBlock, DviLaneDmaCfg},

--- a/src/render.rs
+++ b/src/render.rs
@@ -9,10 +9,7 @@ pub use palette::{init_4bpp_palette, PaletteEntry, BW_PALETTE, GLOBAL_PALETTE};
 
 use core::sync::atomic::{compiler_fence, AtomicBool, Ordering};
 
-use rp_pico::{
-    hal::{sio::SioFifo, Sio},
-    pac,
-};
+use rp2040_hal::{pac, sio::SioFifo, Sio};
 
 use crate::{
     dvi::{tmds::TmdsPair, VERTICAL_REPEAT},


### PR DESCRIPTION
This fever-dream of a PR rips out the BSP specific code from the core0_main, leaving as much common code as possible. I created an example for each BSP (could also be multiple bin.rs files). This is not ideal at all, there are generics everywhere, and this is a crime against the turbofish. 

I do not think that this implementation or #15 are -- as they are now -- good solutions. I think there may be some middle-ground between this idea and #15 that could work.

With the current way the crate is structured, it is very hard to pull out any functionality (like the pinouts) since it is all intertwined. The last option could be to keep it all as one crate and just have cfg'd off blocks with each pinout. This problem may need to be pushed down the road until the crate is a bit more libraryified.