### PR TITLE
New interrupt scheme

### DIFF
--- a/src/dvi/pinout.rs
+++ b/src/dvi/pinout.rs
@@ -1,0 +1,49 @@
+//! Configuration of the DVI pinout.
+
+/// Assignment of HSTX pin pair.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DviPair {
+    D0,
+    D1,
+    D2,
+    Clk,
+}
+
+/// Polarity of HSTX pins
+///
+/// This is the polarity of the lower of the two pins in a pin pair.
+#[allow(unused)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DviPolarity {
+    Pos,
+    Neg,
+}
+
+#[derive(Clone, Copy)]
+pub struct DviPinout {
+    pins: [DviPair; 4],
+    polarity: DviPolarity,
+}
+
+impl DviPinout {
+    pub const fn new(pins: [DviPair; 4], polarity: DviPolarity) -> Self {
+        Self { pins, polarity }
+    }
+
+    pub(crate) const fn cfg_bits(&self, pin: usize) -> u32 {
+        let pair = self.pins[pin / 2];
+        let mut bits = match pair {
+            DviPair::Clk => 1 << 17, // CLK
+            _ => {
+                let perm = pair as u8 as u32 * 10;
+                perm | ((perm + 1) << 8) // SEL_P | SEL_N
+            }
+        };
+        if pin % 2 != self.polarity as u8 as usize {
+            bits |= 1 << 16; // INV
+        }
+        bits
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -8,6 +8,8 @@ pub use font::FONT_HEIGHT;
 
 pub use palette::{Palette1bpp, Palette4bppFast, BW_PALETTE_1BPP};
 
+pub use queue::Queue;
+
 use core::sync::atomic::{compiler_fence, AtomicBool, Ordering};
 
 use crate::{
@@ -21,7 +23,6 @@ use crate::{
 };
 
 use self::{
-    queue::Queue,
     renderlist::{Renderlist, RenderlistBuilder},
     swapcell::SwapCell,
 };

--- a/src/render.rs
+++ b/src/render.rs
@@ -10,9 +10,7 @@ pub use palette::{Palette1bpp, Palette4bppFast, BW_PALETTE_1BPP};
 
 pub use queue::Queue;
 
-use crate::{
-    dvi::BPP,
-};
+use crate::dvi::BPP;
 
 use crate::{
     dvi::VERTICAL_REPEAT,

--- a/src/scan.asm
+++ b/src/scan.asm
@@ -303,7 +303,7 @@ video_scan_solid_16:
     tst r2, #2
     itt ne
     subne r5, #1
-    strhne r6, [r2]!
+    strhne r6, [r2], #2
     // Should this be done by caller?
     orr r6, r6, r6, lsl #16
     subs r5, #4
@@ -319,7 +319,7 @@ video_scan_solid_16:
     stmiahs r2!, {r6}
     tst r5, #1
     it ne
-    strhne r6, [r2]!
+    strhne r6, [r2], #2
     ldmia r0!, {r4, r5, r6}
     bx r4
 
@@ -377,7 +377,7 @@ video_scan_1bpp_pal_16:
     subs r5, #32
     ubfx r3, r4, #0, #1
     ldr r3, [r6, r3, lsl #2]
-    strh r3, [r2]!
+    strh r3, [r2], #2
     video_scan_1bpp_pal_16_2bits #1 #3
     video_scan_1bpp_pal_16_2bits #5 #7
     video_scan_1bpp_pal_16_2bits #9 #11
@@ -390,7 +390,7 @@ video_scan_1bpp_pal_16:
     stmia r2!, {r3}
     ubfx r3, r4, #31, #1
     ldr r3, [r6, r3, lsl #2]
-    strh r3, [r2]!
+    strh r3, [r2], #2
     bhs 7b
 8:
     adds r5, #32 // r5 = count % 32
@@ -399,7 +399,7 @@ video_scan_1bpp_pal_16:
     subs r5, #2
     ubfx r3, r4, #0, #1
     ldr r3, [r6, r3, lsl #2]
-    strh r3, [r2]!
+    strh r3, [r2], #2
     bls 12f
 9:
     subs r5, #2
@@ -412,7 +412,7 @@ video_scan_1bpp_pal_16:
     blo 13f
     ubfx r3, r4, #1, #1
     ldr r3, [r6, r3, lsl #2]
-    strh r3, [r2]!
+    strh r3, [r2], #2
 13:
     ldmia r0!, {r4, r5, r6}
     bx r4
@@ -463,7 +463,7 @@ video_scan_4bpp_pal_16:
     // count % 8 == 7
     ubfx r3, r7, #24, #8
     ldrh r3, [r6, r3, lsl #2]
-    strh r3, [r2]!
+    strh r3, [r2], #2
     ldmia r0!, {r5, r6}
     bx r4
     .align


### PR DESCRIPTION
This PR moves to an interrupt scheme with two interrupts per line: one for the sync pulse, one for video. This scheme will enable configurations with data islands (HDMI audio) and line doubling, and is also more robust in detecting missed deadlines; if a line is missed, an error line is output rather than scanout racing the renderer. Significantly, the interface between DVI out and rendering is much closer to safe, idiomatic Rust; the renderer acquires each line using a MutexGuard-like mechanism to ensure exclusive access. Dropping the guard releases access back to scanout.

It also simplifies the scheduling of rendering. Both the rendering to the intermediate line buffer and from that to video are run synchronously, on a single core. That's less potential CPU bandwidth, as it no longer stripes across both cores, but for now it makes sense to concentrate on configurations in which video rendering can be done on one core.